### PR TITLE
Fix scripts so that they aren't executed unless users have accepted the relevant cookies

### DIFF
--- a/_includes/structure/google_tag.html
+++ b/_includes/structure/google_tag.html
@@ -1,5 +1,5 @@
 <!-- Google Tag Manager -->
-<script>
+<script type="text/plain" data-cookiecategory="analytics">
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
@@ -9,7 +9,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- End Google Tag Manager -->
 
 <!-- Google Analytics: anonymize IP -->
-<script>
+<script type="text/plain" data-cookiecategory="analytics">
 window.dataLayer = window.dataLayer || [];
 window.dataLayer.push({
     'event': 'config',


### PR DESCRIPTION
See the relvant documentation here:

https://github.com/orestbida/cookieconsent/tree/v2.9.2?tab=readme-ov-file#how-to-blockmanage-scripts