### PR TITLE
Implement a fix for the validation not working as desired

### DIFF
--- a/_includes/structure/javascript.html
+++ b/_includes/structure/javascript.html
@@ -14,7 +14,7 @@
 <script src="{{ site.url }}{{ site.baseurl }}/js/classes.js"></script>
 
 <!-- Account Registration modifications -->
-<script src="{{ site.url }}{{ site.baseurl }}/js/register.js"></script>
+<script src="{{ site.url }}{{ site.baseurl }}/js/register.js?v=1.1"></script>
 
 <!-- Cookie management -->
 <script src="https://cdn.jsdelivr.net/gh/orestbida/cookieconsent@v2.9.2/dist/cookieconsent.js" 

--- a/js/register.js
+++ b/js/register.js
@@ -8,6 +8,15 @@ const isCheckboxSelected = () => {
 };
 
 /**
+ * Checks if the user has specified a radio input
+ * @returns {boolean} True if at least one radio is selected
+ */
+const isRadioSelected = (radioInputName) => {
+    const radios = [...document.querySelectorAll('input[name="' + radioInputName + '"]')];
+    return radios.some(radio => radio.checked);
+};
+
+/**
  * Form validation handler
  * Prevents form submission if no newsletter is selected
  */
@@ -15,13 +24,20 @@ document.body.addEventListener('click', event => {
     const { target } = event;
 
     if (target.id === 'tn-account-register-button-register') {
-        if (!isCheckboxSelected()) {
+        // if (!isCheckboxSelected()) {
+        //     event.preventDefault();
+        //     alert('Please select at least one newsletter option.');
+        //     document.querySelector('.tn-interests').scrollIntoView({ block: 'center', behavior: 'smooth' });
+        // }
+
+        if (!isRadioSelected('tn-cust-field-contact_perm_kvp_2-1')) {
             event.preventDefault();
-            alert('Please select at least one newsletter option.');
-            document.querySelector('.tn-interests').scrollIntoView({ block: 'center', behavior: 'smooth' });
+            alert('Please select an option for email updates.');
+            document.querySelector('#tn-cust-category-heading-1').scrollIntoView({ block: 'center', behavior: 'smooth' });
         }
     }
 });
+
 /**
  * Hide/show the email preference options based on whether the user has selected
  * "yes" or "no" under the "Are you happy to receive email updates" form item


### PR DESCRIPTION
The validation wasn't working correctly. It was forcing the user to select a checkbox for which emails newletters they would like to receive, even if they had specified they did _not_ want to receive the email newsletter.

I've reverted this to an earlier state where it only checked that the user had specified whether they wanted to sign up to the email newsletter or not. I will check with the client whether they want further modifications here.