### PR TITLE
Move GTM tag to Head tag for Altair

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -24,9 +24,11 @@
     <link rel="canonical" href="https://tickets.museums.cam.ac.uk"/>
 
     <script>document.documentElement.className += ' js ';</script>
+    {% include /structure/google_tag.html %}
+
 </head>
 <body class="doc-body">
-  {% include /structure/google_tag.html %}
+
 
 <!-- Screen reader skip to main -->
 <a class="sr-only sr-only-focusable doc-skip" href="#content">


### PR DESCRIPTION
Google tag code moved to `<head>` tag at request of Altair as they have had issues debugging the tag. 
